### PR TITLE
Add backend documentation and custom FastAPI docs view

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -20,7 +20,7 @@ The API is available at `http://localhost:8000`. A tailored Swagger UI is served
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
-| `GET` | `/` | Basic service metadata, including API version. |
+| `GET` | `/` | Renders the custom Swagger UI for the API. |
 | `GET` | `/health` | Checks database connectivity and overall service health. |
 | `POST` | `/runs` | Creates a new scan run and schedules asynchronous execution. |
 | `GET` | `/runs/{run_id}` | Retrieves the status and metadata for a scan run. |

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,42 @@
+# Swarm Scanner Backend
+
+This FastAPI service coordinates crawl executions, manages scan results, and streams
+progress updates to connected clients. It exposes REST endpoints that power the
+frontend dashboard and automated scanners.
+
+## Local Development
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+The API is available at `http://localhost:8000`. A tailored Swagger UI is served at
+`http://localhost:8000/documentation` and the OpenAPI schema is exposed from
+`http://localhost:8000/openapi.json`.
+
+## Core Endpoints
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/` | Basic service metadata, including API version. |
+| `GET` | `/health` | Checks database connectivity and overall service health. |
+| `POST` | `/runs` | Creates a new scan run and schedules asynchronous execution. |
+| `GET` | `/runs/{run_id}` | Retrieves the status and metadata for a scan run. |
+| `GET` | `/runs/{run_id}/findings` | Returns all recorded findings for the scan. |
+| `GET` | `/runs/{run_id}/stream` | Streams server-sent events describing scan progress. |
+| `POST` | `/runs/{run_id}/findings/{finding_id}/replay` | Placeholder endpoint for replaying findings. |
+
+### Background Jobs
+
+The backend orchestrates crawler and scanner tasks via asynchronous workers:
+
+- **`run_real_crawler`** fetches pages and stores artifacts per run.
+- **`run_real_scanners`** analyzes crawler output and records findings.
+- **`create_demo_findings`** seeds the database with sample results when no
+  findings are generated.
+
+Server-sent events (SSE) are buffered in-memory per run using the
+`active_connections` dictionary. As scan stages complete, events are appended and
+streamed to subscribed clients via `/runs/{run_id}/stream`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,8 @@
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.openapi.docs import get_swagger_ui_html
+from fastapi.openapi.utils import get_openapi
+from fastapi.responses import JSONResponse, StreamingResponse
 import uuid
 import json
 import asyncio
@@ -19,7 +21,17 @@ from database import (
 )
 from models import CreateScanRequest, ScanRunResponse, FindingResponse, ScanEvent, ScanStatus
 
-app = FastAPI(title="Swarm Scanner API", version="1.0.0")
+app = FastAPI(
+    title="Swarm Scanner API",
+    version="1.0.0",
+    docs_url=None,
+    redoc_url=None,
+    description=(
+        "REST API for coordinating website security scans, "
+        "including crawl execution, finding management, and "
+        "server-sent event streaming for scan progress."
+    ),
+)
 
 # Add startup and shutdown events
 app.add_event_handler("startup", startup_db)
@@ -40,6 +52,26 @@ active_connections: Dict[str, List] = {}
 @app.get("/")
 async def root():
     return {"message": "Swarm Scanner API", "version": "1.0.0"}
+
+
+@app.get("/documentation", include_in_schema=False)
+async def custom_documentation():
+    """Serve a tailored Swagger UI that documents the backend endpoints."""
+
+    return get_swagger_ui_html(
+        openapi_url="/openapi.json",
+        title="Swarm Scanner API Documentation",
+        swagger_favicon_url="https://fastapi.tiangolo.com/img/favicon.png",
+    )
+
+
+@app.get("/openapi.json", include_in_schema=False)
+async def openapi_spec():
+    """Expose the OpenAPI schema used by the custom Swagger UI."""
+
+    return JSONResponse(
+        get_openapi(title=app.title, version=app.version, routes=app.routes)
+    )
 
 @app.get("/health")
 async def health_check():

--- a/backend/main.py
+++ b/backend/main.py
@@ -49,9 +49,11 @@ app.add_middleware(
 # In-memory storage for SSE connections
 active_connections: Dict[str, List] = {}
 
-@app.get("/")
+@app.get("/", include_in_schema=False)
 async def root():
-    return {"message": "Swarm Scanner API", "version": "1.0.0"}
+    """Serve the custom Swagger UI from the base URL."""
+
+    return await custom_documentation()
 
 
 @app.get("/documentation", include_in_schema=False)


### PR DESCRIPTION
## Summary
- document the backend service, setup steps, and key endpoints in a new README
- add a custom Swagger UI endpoint and OpenAPI schema route for the FastAPI app
- disable default docs URLs while enriching the FastAPI app metadata

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d85850e03883339f571cdce955ca2f