### PR TITLE
Add favicon support across apps

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
 import uuid
 import json
 import asyncio
@@ -31,6 +32,14 @@ app = FastAPI(
         "including crawl execution, finding management, and "
         "server-sent event streaming for scan progress."
     ),
+)
+
+# Mount static assets (including the backend favicon)
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+app.mount(
+    "/static",
+    StaticFiles(directory=os.path.join(BASE_DIR, "static")),
+    name="static",
 )
 
 # Add startup and shutdown events
@@ -63,7 +72,7 @@ async def custom_documentation():
     return get_swagger_ui_html(
         openapi_url="/openapi.json",
         title="Swarm Scanner API Documentation",
-        swagger_favicon_url="https://fastapi.tiangolo.com/img/favicon.png",
+        swagger_favicon_url="/static/Favicon.png",
     )
 
 

--- a/demo-app/server.js
+++ b/demo-app/server.js
@@ -1,11 +1,15 @@
 const express = require('express');
 const cors = require('cors');
+const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3001;
 
 // Middleware
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
+
+// Serve static assets (including the demo favicon)
+app.use(express.static(path.join(__dirname, 'public')));
 
 // VULNERABILITY 1: Permissive CORS with credentials
 app.use(cors({
@@ -24,6 +28,7 @@ app.get('/', (req, res) => {
     <html>
     <head>
       <title>Vulnerable Demo App</title>
+      <link rel="icon" type="image/png" href="/Favicon.png" />
       <style>
         body { font-family: Arial, sans-serif; margin: 40px; }
         .form-group { margin: 20px 0; }
@@ -84,7 +89,10 @@ app.get('/search', (req, res) => {
   res.send(`
     <!DOCTYPE html>
     <html>
-    <head><title>Search Results</title></head>
+    <head>
+      <title>Search Results</title>
+      <link rel="icon" type="image/png" href="/Favicon.png" />
+    </head>
     <body>
       <h1>Search Results</h1>
       <p>You searched for: ${query}</p>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" type="image/png" href="%PUBLIC_URL%/Favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta


### PR DESCRIPTION
## Summary
- serve the backend favicon via FastAPI static files and reference it from Swagger UI
- expose the demo app favicon and include it in rendered HTML pages
- update the frontend HTML template to point at the provided PNG favicon

## Testing
- npm start (fails: sh: 1: craco: not found)


------
https://chatgpt.com/codex/tasks/task_e_68d862f0a3248333bde06ea8a7ce2cb4