### PR TITLE
Add session-based authentication to backend and React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Allow committed frontend helpers
+!frontend/src/lib/
+!frontend/src/lib/**
+
 # Virtual environments
 venv/
 env/

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response, Depends, Cookie, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.openapi.utils import get_openapi
@@ -7,10 +7,13 @@ from fastapi.staticfiles import StaticFiles
 import uuid
 import json
 import asyncio
-from datetime import datetime
-from typing import Dict, List
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
 import os
+import secrets
 from dotenv import load_dotenv
+from pydantic import BaseModel, EmailStr, Field
+from argon2 import PasswordHasher
 
 # Load environment variables
 load_dotenv()
@@ -47,14 +50,105 @@ app.mount(
 app.add_event_handler("startup", startup_db)
 app.add_event_handler("shutdown", shutdown_db)
 
+# Configuration
+SESSION_COOKIE = os.getenv("SESSION_COOKIE_NAME", "sid")
+SESSION_TTL_HOURS = int(os.getenv("SESSION_TTL_HOURS", "168"))
+SESSION_TTL = timedelta(hours=SESSION_TTL_HOURS)
+CORS_ORIGINS = [
+    origin.strip()
+    for origin in os.getenv(
+        "CORS_ORIGIN",
+        "http://localhost:3000,http://localhost:3002,http://localhost:5173"
+    ).split(",")
+    if origin.strip()
+]
+COOKIE_SECURE = os.getenv("SESSION_COOKIE_SECURE", "false").lower() == "true"
+COOKIE_SAMESITE = os.getenv("SESSION_COOKIE_SAMESITE", "lax")
+
+ph = PasswordHasher()
+
 # CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://localhost:3002"],  # React dev server
+    allow_origins=CORS_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+class SignupIn(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8)
+    name: Optional[str] = None
+
+
+class LoginIn(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class MeOut(BaseModel):
+    id: str
+    email: EmailStr
+    roles: List[str]
+
+
+async def ensure_auth_indexes():
+    db = await get_database()
+    users_collection = db["users"]
+    sessions_collection = db["sessions"]
+
+    await users_collection.create_index("email", unique=True)
+    await sessions_collection.create_index("token", unique=True)
+    await sessions_collection.create_index("expiresAt", expireAfterSeconds=0)
+
+
+async def startup_auth():
+    await ensure_auth_indexes()
+
+
+app.add_event_handler("startup", startup_auth)
+
+
+def cookie_opts():
+    return {
+        "httponly": True,
+        "secure": COOKIE_SECURE,
+        "samesite": COOKIE_SAMESITE,
+        "path": "/",
+        "max_age": int(SESSION_TTL.total_seconds()),
+    }
+
+
+async def get_current_user(
+    sid: Optional[str] = Cookie(default=None, alias=SESSION_COOKIE)
+):
+    if not sid:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
+
+    db = await get_database()
+    sessions_collection = db["sessions"]
+    users_collection = db["users"]
+
+    now = datetime.utcnow()
+    session = await sessions_collection.find_one({
+        "token": sid,
+        "expiresAt": {"$gt": now},
+    })
+
+    if not session:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="session_expired")
+
+    user = await users_collection.find_one({"_id": session["userId"]})
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="user_not_found")
+
+    return {
+        "id": str(user["_id"]),
+        "email": user["email"],
+        "roles": user.get("roles", ["user"]),
+    }
 
 # In-memory storage for SSE connections
 active_connections: Dict[str, List] = {}
@@ -96,10 +190,95 @@ async def health_check():
     except Exception as e:
         return {"status": "unhealthy", "error": str(e)}
 
+
+@app.post("/api/auth/signup", status_code=status.HTTP_201_CREATED)
+async def signup(payload: SignupIn, resp: Response):
+    db = await get_database()
+    users_collection = db["users"]
+    sessions_collection = db["sessions"]
+
+    existing = await users_collection.find_one({"email": payload.email.lower()})
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="email_taken")
+
+    pw_hash = ph.hash(payload.password)
+    user_doc = {
+        "email": payload.email.lower(),
+        "passwordHash": pw_hash,
+        "name": payload.name,
+        "roles": ["user"],
+        "createdAt": datetime.utcnow(),
+    }
+
+    result = await users_collection.insert_one(user_doc)
+
+    token = secrets.token_hex(32)
+    expires_at = datetime.utcnow() + SESSION_TTL
+    await sessions_collection.insert_one({
+        "userId": result.inserted_id,
+        "token": token,
+        "createdAt": datetime.utcnow(),
+        "expiresAt": expires_at,
+    })
+
+    resp.set_cookie(SESSION_COOKIE, token, **cookie_opts())
+    return {"id": str(result.inserted_id), "email": payload.email}
+
+
+@app.post("/api/auth/login")
+async def login(payload: LoginIn, resp: Response):
+    db = await get_database()
+    users_collection = db["users"]
+    sessions_collection = db["sessions"]
+
+    user = await users_collection.find_one({"email": payload.email.lower()})
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_credentials")
+
+    try:
+        ph.verify(user["passwordHash"], payload.password)
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_credentials")
+
+    token = secrets.token_hex(32)
+    expires_at = datetime.utcnow() + SESSION_TTL
+    await sessions_collection.insert_one({
+        "userId": user["_id"],
+        "token": token,
+        "createdAt": datetime.utcnow(),
+        "expiresAt": expires_at,
+    })
+
+    resp.set_cookie(SESSION_COOKIE, token, **cookie_opts())
+    return {"id": str(user["_id"]), "email": user["email"]}
+
+
+@app.get("/api/auth/me", response_model=MeOut)
+async def me(user=Depends(get_current_user)):
+    return user
+
+
+@app.post("/api/auth/logout")
+async def logout(resp: Response, sid: Optional[str] = Cookie(default=None, alias=SESSION_COOKIE)):
+    if sid:
+        db = await get_database()
+        sessions_collection = db["sessions"]
+        await sessions_collection.delete_one({"token": sid})
+
+    resp.delete_cookie(SESSION_COOKIE, path="/", samesite=COOKIE_SAMESITE, secure=COOKIE_SECURE)
+    return {"ok": True}
+
+
+@app.get("/api/secret")
+async def secret(user=Depends(get_current_user)):
+    return {"message": f"Hi {user['email']}, only authed users see this."}
+
+
 @app.post("/runs", response_model=dict)
 async def create_scan(
     scan_request: CreateScanRequest,
-    request: Request
+    request: Request,
+    user=Depends(get_current_user)
 ):
     if not scan_request.consent:
         raise HTTPException(status_code=400, detail="Consent is required to start a scan")
@@ -129,7 +308,7 @@ async def create_scan(
     return {"run_id": run_id, "status": "queued"}
 
 @app.get("/runs/{run_id}", response_model=ScanRunResponse)
-async def get_scan_status(run_id: str):
+async def get_scan_status(run_id: str, user=Depends(get_current_user)):
     scan_run = await get_scan_run(run_id)
     if not scan_run:
         raise HTTPException(status_code=404, detail="Scan run not found")
@@ -148,7 +327,7 @@ async def get_scan_status(run_id: str):
     )
 
 @app.get("/runs/{run_id}/findings", response_model=List[FindingResponse])
-async def get_scan_findings(run_id: str):
+async def get_scan_findings(run_id: str, user=Depends(get_current_user)):
     findings = await get_findings_by_run(run_id)
 
     return [
@@ -169,7 +348,7 @@ async def get_scan_findings(run_id: str):
     ]
 
 @app.get("/runs/{run_id}/stream")
-async def stream_scan_events(run_id: str):
+async def stream_scan_events(run_id: str, user=Depends(get_current_user)):
     # Verify run exists
     scan_run = await get_scan_run(run_id)
     if not scan_run:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ pytest==8.3.3
 pytest-asyncio==0.24.0
 beanie==1.27.0
 agentmail>=0.0.60
+argon2-cffi==23.1.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ pytest-asyncio==0.24.0
 beanie==1.27.0
 agentmail>=0.0.60
 argon2-cffi==23.1.0
+email-validator==2.1.1

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,23 +1,29 @@
 "use client"
 
 import { useState } from "react"
-import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom"
+import { BrowserRouter as Router, Routes, Route, Navigate, useNavigate } from "react-router-dom"
 import { motion, AnimatePresence } from "framer-motion"
 import axios from "axios"
 import ScanDashboard from "./components/ScanDashboard"
 import ScanResults from "./components/ScanResults"
 import ConsentModal from "./components/ConsentModal"
 import NavigationBar from "./components/NavigationBar"
-import { Shield } from "lucide-react"
+import ProtectedRoute from "./components/ProtectedRoute"
+import LoginPage from "./pages/LoginPage"
+import SignupPage from "./pages/SignupPage"
+import { AuthProvider, useAuth } from "./context/AuthContext"
+import { API_BASE_URL } from "./lib/api"
 import "./index.css"
 
-// Configure axios defaults
-axios.defaults.baseURL = "http://localhost:8000"
+axios.defaults.baseURL = API_BASE_URL
+axios.defaults.withCredentials = true
 
-function App() {
+const AppRoutes = () => {
   const [currentScan, setCurrentScan] = useState(null)
   const [showConsent, setShowConsent] = useState(false)
   const [pendingScanRequest, setPendingScanRequest] = useState(null)
+  const { user, logout, loading } = useAuth()
+  const navigate = useNavigate()
 
   const handleStartScan = async (scanRequest) => {
     setPendingScanRequest(scanRequest)
@@ -41,12 +47,15 @@ function App() {
 
       setShowConsent(false)
       setPendingScanRequest(null)
-      
-      // Navigate to results page after successful scan start
-      window.location.href = `/scan/${response.data.run_id}`
+
+      navigate(`/scan/${response.data.run_id}`)
     } catch (error) {
       console.error("Failed to start scan:", error)
-      alert("Failed to start scan: " + (error.response?.data?.detail || error.message))
+      if (error.response?.status === 401) {
+        navigate("/login")
+      } else {
+        alert("Failed to start scan: " + (error.response?.data?.detail || error.message))
+      }
     }
   }
 
@@ -56,33 +65,76 @@ function App() {
   }
 
   const handleNewScan = () => {
-    setCurrentScan(null); 
+    setCurrentScan(null)
+  }
+
+  const handleLogout = async () => {
+    await logout()
+    setCurrentScan(null)
+    setPendingScanRequest(null)
+    setShowConsent(false)
+    navigate("/login")
   }
 
   return (
-    <Router>
-      <div className="min-h-screen bg-background relative overflow-hidden" style={{ 
-        transform: 'translateZ(0)', 
-        WebkitTransform: 'translateZ(0)',
-        willChange: 'scroll-position'
-      }}>
-        {/* Background Grid */}
-        <div className="fixed inset-0 swarm-grid pointer-events-none" />
+    <div
+      className="min-h-screen bg-background relative overflow-hidden"
+      style={{
+        transform: "translateZ(0)",
+        WebkitTransform: "translateZ(0)",
+        willChange: "scroll-position",
+      }}
+    >
+      <div className="fixed inset-0 swarm-grid pointer-events-none" />
 
-        {/* Static Background Elements */}
-        <div className="fixed inset-0 pointer-events-none">
-          <div className="absolute top-20 left-20 w-48 h-48 bg-primary/2 rounded-full blur-xl" />
-          <div className="absolute bottom-20 right-20 w-64 h-64 bg-primary/1 rounded-full blur-xl" />
-        </div>
+      <div className="fixed inset-0 pointer-events-none">
+        <div className="absolute top-20 left-20 w-48 h-48 bg-primary/2 rounded-full blur-xl" />
+        <div className="absolute bottom-20 right-20 w-64 h-64 bg-primary/1 rounded-full blur-xl" />
+      </div>
 
-        <NavigationBar currentScan={currentScan} onNewScan={handleNewScan} />
+      <NavigationBar
+        currentScan={currentScan}
+        onNewScan={handleNewScan}
+        user={user}
+        onLogout={handleLogout}
+        authLoading={loading}
+      />
 
-        <main className="max-w-7xl mx-auto py-8 sm:px-6 lg:px-8 relative z-10">
-          <AnimatePresence mode="wait">
-            <Routes>
-              <Route
-                path="/"
-                element={
+      <main className="max-w-7xl mx-auto py-8 sm:px-6 lg:px-8 relative z-10">
+        <AnimatePresence mode="wait">
+          <Routes>
+            <Route
+              path="/login"
+              element={
+                <motion.div
+                  key="login"
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -20 }}
+                  transition={{ duration: 0.5 }}
+                >
+                  <LoginPage />
+                </motion.div>
+              }
+            />
+            <Route
+              path="/signup"
+              element={
+                <motion.div
+                  key="signup"
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -20 }}
+                  transition={{ duration: 0.5 }}
+                >
+                  <SignupPage />
+                </motion.div>
+              }
+            />
+            <Route
+              path="/"
+              element={
+                <ProtectedRoute>
                   <motion.div
                     key="dashboard"
                     initial={{ opacity: 0, y: 20 }}
@@ -92,11 +144,13 @@ function App() {
                   >
                     <ScanDashboard onStartScan={handleStartScan} />
                   </motion.div>
-                }
-              />
-              <Route
-                path="/scan/:runId"
-                element={
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/scan/:runId"
+              element={
+                <ProtectedRoute>
                   <motion.div
                     key="results"
                     initial={{ opacity: 0, y: 20 }}
@@ -106,24 +160,35 @@ function App() {
                   >
                     <ScanResults />
                   </motion.div>
-                }
-              />
-            </Routes>
-          </AnimatePresence>
-        </main>
-
-        <AnimatePresence>
-          {showConsent && (
-            <ConsentModal
-              isOpen={showConsent}
-              onAccept={handleConsentAccepted}
-              onDecline={handleConsentDeclined}
-              targetUrl={pendingScanRequest?.target_url}
+                </ProtectedRoute>
+              }
             />
-          )}
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
         </AnimatePresence>
-      </div>
-    </Router>
+      </main>
+
+      <AnimatePresence>
+        {showConsent && (
+          <ConsentModal
+            isOpen={showConsent}
+            onAccept={handleConsentAccepted}
+            onDecline={handleConsentDeclined}
+            targetUrl={pendingScanRequest?.target_url}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
+
+function App() {
+  return (
+    <AuthProvider>
+      <Router>
+        <AppRoutes />
+      </Router>
+    </AuthProvider>
   )
 }
 

--- a/frontend/src/components/ConsentModal.js
+++ b/frontend/src/components/ConsentModal.js
@@ -1,6 +1,6 @@
 "use client"
 import { motion, AnimatePresence } from "framer-motion"
-import { AlertTriangle, Shield, X } from "lucide-react"
+import { AlertTriangle, X } from "lucide-react"
 
 const ConsentModal = ({ isOpen, onAccept, onDecline, targetUrl }) => {
   return (

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -3,23 +3,26 @@
 import { useState } from "react"
 import { Link, useLocation, useNavigate } from "react-router-dom"
 import { motion, AnimatePresence } from "framer-motion"
-import { Shield, Play, AlertTriangle } from "lucide-react"
+import { Shield, Play, AlertTriangle, LogOut, User } from "lucide-react"
 
-const NavigationBar = ({ currentScan, onNewScan }) => {
+const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = false }) => {
   const location = useLocation()
   const navigate = useNavigate()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
 
+  const isAuthenticated = Boolean(user)
+  const canStartScan = isAuthenticated && !authLoading
+
   // Check if we're currently on a scan results page
   const isOnScanResults = location.pathname.startsWith("/scan/")
 
   const navItems = [
-    { name: "Dashboard", path: "/" },
-    { 
-      name: "Results", 
+    { name: "Dashboard", path: "/", disabled: !isAuthenticated || authLoading },
+    {
+      name: "Results",
       path: currentScan ? `/scan/${currentScan.runId}` : (isOnScanResults ? location.pathname : "/"),
-      disabled: !currentScan && !isOnScanResults
+      disabled: !isAuthenticated || authLoading || (!currentScan && !isOnScanResults)
     }
   ]
 
@@ -32,6 +35,13 @@ const NavigationBar = ({ currentScan, onNewScan }) => {
   }
 
   const handleNewScanClick = () => {
+    if (!canStartScan) {
+      if (!authLoading) {
+        navigate("/login")
+      }
+      return
+    }
+
     // If there's an active scan, show confirmation dialog
     if (currentScan && (currentScan.status === "running" || currentScan.status === "completed")) {
       setShowConfirmDialog(true)
@@ -52,6 +62,13 @@ const NavigationBar = ({ currentScan, onNewScan }) => {
 
   const handleCancelNewScan = () => {
     setShowConfirmDialog(false)
+  }
+
+  const handleLogoutClick = async () => {
+    if (onLogout) {
+      await onLogout()
+      setIsMenuOpen(false)
+    }
   }
 
   return (
@@ -113,16 +130,51 @@ const NavigationBar = ({ currentScan, onNewScan }) => {
               ))}
             </nav>
 
-            {/* CTA Button */}
-            <motion.button
-              onClick={handleNewScanClick}
-              className="glass-card px-6 py-2 text-sm font-medium text-foreground hover:bg-primary/10 transition-all duration-300 rounded-lg border border-border/50 hover:border-primary/40 flex items-center space-x-2"
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-            >
-              <Play className="h-4 w-4" />
-              <span>New Scan</span>
-            </motion.button>
+            {/* Auth Actions */}
+            <div className="hidden md:flex items-center space-x-3">
+              {isAuthenticated ? (
+                <>
+                  <div className="glass-card flex items-center space-x-2 rounded-lg border border-border/50 px-3 py-2 text-xs text-muted-foreground">
+                    <User className="h-4 w-4" />
+                    <span className="font-medium text-foreground/80">{user.email}</span>
+                  </div>
+                  <motion.button
+                    onClick={handleNewScanClick}
+                    disabled={!canStartScan}
+                    className="glass-card px-6 py-2 text-sm font-medium text-foreground hover:bg-primary/10 transition-all duration-300 rounded-lg border border-border/50 hover:border-primary/40 flex items-center space-x-2 disabled:opacity-50"
+                    whileHover={{ scale: canStartScan ? 1.05 : 1 }}
+                    whileTap={{ scale: canStartScan ? 0.95 : 1 }}
+                  >
+                    <Play className="h-4 w-4" />
+                    <span>New Scan</span>
+                  </motion.button>
+                  <motion.button
+                    onClick={handleLogoutClick}
+                    className="glass-card px-4 py-2 text-sm font-medium text-foreground hover:bg-muted/20 transition-all duration-300 rounded-lg border border-border/50 flex items-center space-x-2"
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                  >
+                    <LogOut className="h-4 w-4" />
+                    <span>Log out</span>
+                  </motion.button>
+                </>
+              ) : (
+                <>
+                  <Link
+                    to="/login"
+                    className="glass-card px-4 py-2 text-sm font-medium text-foreground hover:bg-muted/20 transition-all duration-300 rounded-lg border border-border/50"
+                  >
+                    Log in
+                  </Link>
+                  <Link
+                    to="/signup"
+                    className="bg-primary text-primary-foreground px-4 py-2 text-sm font-medium rounded-lg hover:bg-primary/90 transition-all duration-300"
+                  >
+                    Sign up
+                  </Link>
+                </>
+              )}
+            </div>
 
             {/* Mobile Menu Button */}
             <button
@@ -175,11 +227,49 @@ const NavigationBar = ({ currentScan, onNewScan }) => {
                         ? "text-primary"
                         : "text-foreground/70 hover:text-foreground"
                     }`}
-                    onClick={() => setIsMenuOpen(false)}
+                    onClick={() => {
+                      if (!item.disabled) {
+                        setIsMenuOpen(false)
+                      }
+                    }}
                   >
                     {item.name}
                   </Link>
                 ))}
+                {isAuthenticated ? (
+                  <>
+                    <button
+                      onClick={handleNewScanClick}
+                      disabled={!canStartScan}
+                      className="glass-card px-4 py-2 text-left text-sm font-medium text-foreground border border-border/50 rounded-lg hover:bg-primary/10 disabled:opacity-50"
+                    >
+                      Start new scan
+                    </button>
+                    <button
+                      onClick={handleLogoutClick}
+                      className="glass-card px-4 py-2 text-left text-sm font-medium text-foreground border border-border/50 rounded-lg hover:bg-muted/20"
+                    >
+                      Log out
+                    </button>
+                  </>
+                ) : (
+                  <div className="flex flex-col space-y-3">
+                    <Link
+                      to="/login"
+                      className="glass-card px-4 py-2 text-sm font-medium text-foreground border border-border/50 rounded-lg hover:bg-muted/20"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
+                      Log in
+                    </Link>
+                    <Link
+                      to="/signup"
+                      className="bg-primary text-primary-foreground px-4 py-2 text-sm font-medium rounded-lg hover:bg-primary/90"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
+                      Sign up
+                    </Link>
+                  </div>
+                )}
               </div>
             </motion.div>
           )}

--- a/frontend/src/components/ProtectedRoute.js
+++ b/frontend/src/components/ProtectedRoute.js
@@ -1,0 +1,27 @@
+"use client"
+
+import { Navigate, useLocation } from "react-router-dom"
+import { useAuth } from "../context/AuthContext"
+
+const ProtectedRoute = ({ children }) => {
+  const location = useLocation()
+  const { user, loading } = useAuth()
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <div className="glass-card px-6 py-4 rounded-xl text-center">
+          <p className="text-sm text-muted-foreground">Checking authentication…</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: location }} />
+  }
+
+  return children
+}
+
+export default ProtectedRoute

--- a/frontend/src/components/ScanResults.js
+++ b/frontend/src/components/ScanResults.js
@@ -1,7 +1,7 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { useParams } from "react-router-dom"
+import { useState, useEffect, useCallback } from "react"
+import { useNavigate, useParams } from "react-router-dom"
 import { motion, AnimatePresence } from "framer-motion"
 import axios from "axios"
 import {
@@ -15,16 +15,45 @@ import {
   CheckCircle,
   ExternalLink,
   Activity,
-  Target,
 } from "lucide-react"
+import { API_BASE_URL } from "../lib/api"
 
 const ScanResults = () => {
   const { runId } = useParams();
+  const navigate = useNavigate();
   const [scanStatus, setScanStatus] = useState(null);
   const [findings, setFindings] = useState([]);
   const [selectedFinding, setSelectedFinding] = useState(null);
   const [loading, setLoading] = useState(true);
   const [events, setEvents] = useState([]);
+
+  const fetchScanStatus = useCallback(async () => {
+    try {
+      const response = await axios.get(`/runs/${runId}`);
+      setScanStatus(response.data);
+      setLoading(false);
+    } catch (error) {
+      console.error('Failed to fetch scan status:', error);
+      if (error.response?.status === 401) {
+        navigate('/login');
+      }
+      setLoading(false);
+    }
+  }, [navigate, runId]);
+
+  const fetchFindings = useCallback(async () => {
+    try {
+      console.log(`🔍 Fetching findings for run ${runId}`);
+      const response = await axios.get(`/runs/${runId}/findings`);
+      console.log(`✅ Found ${response.data.length} findings:`, response.data.slice(0, 3));
+      setFindings(response.data);
+    } catch (error) {
+      console.error('Failed to fetch findings:', error);
+      if (error.response?.status === 401) {
+        navigate('/login');
+      }
+    }
+  }, [navigate, runId]);
 
   useEffect(() => {
     if (!runId) return;
@@ -34,7 +63,7 @@ const ScanResults = () => {
     fetchFindings();
 
     // Set up SSE for real-time updates
-    const eventSource = new EventSource(`http://localhost:8000/runs/${runId}/stream`);
+    const eventSource = new EventSource(`${API_BASE_URL}/runs/${runId}/stream`, { withCredentials: true });
 
     eventSource.onmessage = (event) => {
       const data = JSON.parse(event.data);
@@ -58,29 +87,7 @@ const ScanResults = () => {
       eventSource.close();
     };
 
-  }, [runId]);
-
-  const fetchScanStatus = async () => {
-    try {
-      const response = await axios.get(`/runs/${runId}`);
-      setScanStatus(response.data);
-      setLoading(false);
-    } catch (error) {
-      console.error('Failed to fetch scan status:', error);
-      setLoading(false);
-    }
-  };
-
-  const fetchFindings = async () => {
-    try {
-      console.log(`🔍 Fetching findings for run ${runId}`);
-      const response = await axios.get(`/runs/${runId}/findings`);
-      console.log(`✅ Found ${response.data.length} findings:`, response.data.slice(0, 3));
-      setFindings(response.data);
-    } catch (error) {
-      console.error('Failed to fetch findings:', error);
-    }
-  };
+  }, [runId, fetchFindings, fetchScanStatus]);
 
   const getSeverityColor = (severity) => {
     switch (severity) {

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,0 +1,69 @@
+"use client"
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react"
+import { login as loginRequest, logout as logoutRequest, me as fetchMe, signup as signupRequest } from "../lib/auth"
+
+const AuthContext = createContext({
+  user: null,
+  loading: true,
+  login: async () => {},
+  signup: async () => {},
+  logout: async () => {},
+  refresh: async () => {},
+})
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const currentUser = await fetchMe()
+      setUser(currentUser)
+    } catch (error) {
+      setUser(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const login = useCallback(async (email, password) => {
+    try {
+      await loginRequest(email, password)
+      await refresh()
+    } catch (error) {
+      throw new Error(error.message || "Login failed")
+    }
+  }, [refresh])
+
+  const signup = useCallback(async (email, password, name) => {
+    try {
+      await signupRequest(email, password, name)
+      await refresh()
+    } catch (error) {
+      throw new Error(error.message || "Signup failed")
+    }
+  }, [refresh])
+
+  const logout = useCallback(async () => {
+    try {
+      await logoutRequest()
+    } finally {
+      setUser(null)
+      setLoading(false)
+    }
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, signup, logout, refresh }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,24 @@
+export const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8000"
+
+export async function api(path, init = {}) {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers || {}),
+    },
+    ...init,
+  })
+
+  if (!response.ok) {
+    const message = await response.text().catch(() => response.statusText)
+    throw new Error(message || `HTTP ${response.status}`)
+  }
+
+  const contentType = response.headers.get("content-type") || ""
+  if (response.status === 204 || !contentType.includes("application/json")) {
+    return null
+  }
+
+  return response.json()
+}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,4 +1,4 @@
-export const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8000"
+export const API_BASE_URL = process.env.REACT_APP_API_URL || "http://localhost:8000"
 
 export async function api(path, init = {}) {
   const response = await fetch(`${API_BASE_URL}${path}`, {

--- a/frontend/src/lib/auth.js
+++ b/frontend/src/lib/auth.js
@@ -1,0 +1,20 @@
+import { api } from "./api"
+
+export const signup = (email, password, name) =>
+  api("/api/auth/signup", {
+    method: "POST",
+    body: JSON.stringify({ email, password, name }),
+  })
+
+export const login = (email, password) =>
+  api("/api/auth/login", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  })
+
+export const me = () => api("/api/auth/me")
+
+export const logout = () =>
+  api("/api/auth/logout", {
+    method: "POST",
+  })

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,0 +1,102 @@
+"use client"
+
+import { useState } from "react"
+import { Link, useLocation, useNavigate } from "react-router-dom"
+import { motion } from "framer-motion"
+import { useAuth } from "../context/AuthContext"
+
+const LoginPage = () => {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const from = location.state?.from?.pathname || "/"
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setError("")
+    setIsSubmitting(true)
+
+    try {
+      await login(email, password)
+      navigate(from, { replace: true })
+    } catch (err) {
+      setError(err.message || "Login failed")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-140px)] items-center justify-center px-4">
+      <motion.div
+        className="glass-card w-full max-w-md rounded-2xl p-8"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <h2 className="text-2xl font-semibold text-foreground">Welcome back</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Sign in to manage scans and review findings.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-8 space-y-6">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-foreground">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="mt-2 w-full rounded-xl border border-border bg-input px-4 py-3 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-foreground">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="mt-2 w-full rounded-xl border border-border bg-input px-4 py-3 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+              required
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-400">{error}</p>}
+
+          <motion.button
+            type="submit"
+            className="flex w-full items-center justify-center rounded-xl bg-primary px-4 py-3 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-60"
+            disabled={isSubmitting}
+            whileTap={{ scale: 0.97 }}
+            whileHover={{ scale: isSubmitting ? 1 : 1.01 }}
+          >
+            {isSubmitting ? "Signing in…" : "Sign in"}
+          </motion.button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          Need an account?{" "}
+          <Link to="/signup" className="text-primary hover:underline">
+            Create one here
+          </Link>
+        </p>
+      </motion.div>
+    </div>
+  )
+}
+
+export default LoginPage

--- a/frontend/src/pages/SignupPage.js
+++ b/frontend/src/pages/SignupPage.js
@@ -1,0 +1,139 @@
+"use client"
+
+import { useState } from "react"
+import { Link, useLocation, useNavigate } from "react-router-dom"
+import { motion } from "framer-motion"
+import { useAuth } from "../context/AuthContext"
+
+const SignupPage = () => {
+  const { signup } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [email, setEmail] = useState("")
+  const [name, setName] = useState("")
+  const [password, setPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [error, setError] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const from = location.state?.from?.pathname || "/"
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setError("")
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match")
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      await signup(email, password, name || undefined)
+      navigate(from, { replace: true })
+    } catch (err) {
+      setError(err.message || "Signup failed")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-140px)] items-center justify-center px-4">
+      <motion.div
+        className="glass-card w-full max-w-md rounded-2xl p-8"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <h2 className="text-2xl font-semibold text-foreground">Create your account</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Start scanning applications with secure session-based auth.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-8 space-y-6">
+          <div>
+            <label htmlFor="name" className="block text-sm font-medium text-foreground">
+              Name (optional)
+            </label>
+            <input
+              id="name"
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="mt-2 w-full rounded-xl border border-border bg-input px-4 py-3 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-foreground">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="mt-2 w-full rounded-xl border border-border bg-input px-4 py-3 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-foreground">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="mt-2 w-full rounded-xl border border-border bg-input px-4 py-3 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+              required
+              minLength={8}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="confirmPassword" className="block text-sm font-medium text-foreground">
+              Confirm Password
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              className="mt-2 w-full rounded-xl border border-border bg-input px-4 py-3 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+              required
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-400">{error}</p>}
+
+          <motion.button
+            type="submit"
+            className="flex w-full items-center justify-center rounded-xl bg-primary px-4 py-3 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-60"
+            disabled={isSubmitting}
+            whileTap={{ scale: 0.97 }}
+            whileHover={{ scale: isSubmitting ? 1 : 1.01 }}
+          >
+            {isSubmitting ? "Creating account…" : "Sign up"}
+          </motion.button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link to="/login" className="text-primary hover:underline">
+            Sign in
+          </Link>
+        </p>
+      </motion.div>
+    </div>
+  )
+}
+
+export default SignupPage


### PR DESCRIPTION
## Summary
- implement Mongo-backed session authentication routes in the FastAPI backend and guard scan APIs
- add shared auth utilities, provider, and protected routing to the React frontend with login and signup pages
- update navigation to reflect auth state and allow fetch helpers while keeping new lib files committed

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d8985b6c9c8333ad9ebc59f648a8b7