### PR TITLE
Add scan history dropdown and track scan ownership

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -25,6 +25,7 @@ class ScanRun(Document):
     notify_email: Optional[str] = None
     max_pages: int = 30
     risk_score: int = 0
+    user_id: Optional[str] = None
 
     class Settings:
         name = "scan_runs"
@@ -120,6 +121,15 @@ async def create_scan_run(scan_data: dict) -> ScanRun:
 async def get_scan_run(run_id: str) -> Optional[ScanRun]:
     """Get scan run by ID"""
     return await ScanRun.find_one(ScanRun.id == run_id)
+
+async def get_scan_runs_by_user(user_id: str) -> List[ScanRun]:
+    """Get all scan runs that belong to a specific user"""
+    runs = await ScanRun.find(ScanRun.user_id == user_id).to_list()
+
+    # Sort newest first for easier display in the UI
+    runs.sort(key=lambda run: run.created_at, reverse=True)
+
+    return runs
 
 async def update_scan_run(run_id: str, update_data: dict) -> Optional[ScanRun]:
     """Update scan run"""

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,7 +21,8 @@ load_dotenv()
 from database import (
     startup_db, shutdown_db, get_database,
     create_scan_run, get_scan_run, update_scan_run,
-    create_finding, get_findings_by_run, get_finding
+    create_finding, get_findings_by_run, get_finding,
+    get_scan_runs_by_user
 )
 from models import CreateScanRequest, ScanRunResponse, FindingResponse, ScanEvent, ScanStatus
 from agent_mail import dispatch_post_scan_email
@@ -295,6 +296,7 @@ async def create_scan(
         "max_pages": scan_request.max_pages,
         "notify_email": notify_email,
         "consent_ip": request.client.host,
+        "user_id": user["id"],
     }
 
     scan_run = await create_scan_run(scan_data)
@@ -307,10 +309,35 @@ async def create_scan(
 
     return {"run_id": run_id, "status": "queued"}
 
+@app.get("/runs", response_model=List[ScanRunResponse])
+async def list_scan_runs(user=Depends(get_current_user)):
+    runs = await get_scan_runs_by_user(user["id"])
+
+    responses = []
+    for run in runs:
+        findings = await get_findings_by_run(run.id)
+        responses.append(
+            ScanRunResponse(
+                id=run.id,
+                target_url=run.target_url,
+                status=run.status,
+                created_at=run.created_at,
+                completed_at=run.completed_at,
+                risk_score=run.risk_score,
+                finding_count=len(findings)
+            )
+        )
+
+    return responses
+
+
 @app.get("/runs/{run_id}", response_model=ScanRunResponse)
 async def get_scan_status(run_id: str, user=Depends(get_current_user)):
     scan_run = await get_scan_run(run_id)
     if not scan_run:
+        raise HTTPException(status_code=404, detail="Scan run not found")
+
+    if scan_run.user_id != user["id"]:
         raise HTTPException(status_code=404, detail="Scan run not found")
 
     findings = await get_findings_by_run(run_id)
@@ -328,6 +355,10 @@ async def get_scan_status(run_id: str, user=Depends(get_current_user)):
 
 @app.get("/runs/{run_id}/findings", response_model=List[FindingResponse])
 async def get_scan_findings(run_id: str, user=Depends(get_current_user)):
+    scan_run = await get_scan_run(run_id)
+    if not scan_run or scan_run.user_id != user["id"]:
+        raise HTTPException(status_code=404, detail="Scan run not found")
+
     findings = await get_findings_by_run(run_id)
 
     return [
@@ -351,7 +382,7 @@ async def get_scan_findings(run_id: str, user=Depends(get_current_user)):
 async def stream_scan_events(run_id: str, user=Depends(get_current_user)):
     # Verify run exists
     scan_run = await get_scan_run(run_id)
-    if not scan_run:
+    if not scan_run or scan_run.user_id != user["id"]:
         raise HTTPException(status_code=404, detail="Scan run not found")
 
     async def event_generator():

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import NavigationBar from "./components/NavigationBar"
 import ProtectedRoute from "./components/ProtectedRoute"
 import LoginPage from "./pages/LoginPage"
 import SignupPage from "./pages/SignupPage"
+import ScanHistoryPage from "./pages/ScanHistoryPage"
 import { AuthProvider, useAuth } from "./context/AuthContext"
 import { API_BASE_URL } from "./lib/api"
 import "./index.css"
@@ -159,6 +160,22 @@ const AppRoutes = () => {
                     transition={{ duration: 0.5 }}
                   >
                     <ScanResults />
+                  </motion.div>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/runs"
+              element={
+                <ProtectedRoute>
+                  <motion.div
+                    key="history"
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -20 }}
+                    transition={{ duration: 0.5 }}
+                  >
+                    <ScanHistoryPage />
                   </motion.div>
                 </ProtectedRoute>
               }

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -1,116 +1,24 @@
 "use client"
 
-import { useState, useEffect, useCallback, useRef } from "react"
-import axios from "axios"
+import { useState, useEffect } from "react"
 import { Link, useLocation, useNavigate } from "react-router-dom"
 import { motion, AnimatePresence } from "framer-motion"
-import { Shield, Play, AlertTriangle, LogOut, User, ChevronDown } from "lucide-react"
-
-const STATUS_STYLES = {
-  queued: "bg-amber-500/10 text-amber-400",
-  running: "bg-sky-500/10 text-sky-400",
-  completed: "bg-emerald-500/10 text-emerald-400",
-  failed: "bg-rose-500/10 text-rose-400"
-}
-
-const formatStatusLabel = (status) => {
-  if (!status) return ""
-  return status.charAt(0).toUpperCase() + status.slice(1)
-}
-
-const formatDateTime = (value) => {
-  if (!value) return ""
-  try {
-    return new Date(value).toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit"
-    })
-  } catch (error) {
-    return value
-  }
-}
+import { Shield, Play, AlertTriangle, LogOut, User } from "lucide-react"
 
 const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = false }) => {
   const location = useLocation()
   const navigate = useNavigate()
-  const isMountedRef = useRef(true)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
-  const [showResultsDropdown, setShowResultsDropdown] = useState(false)
-  const [showMobileResults, setShowMobileResults] = useState(false)
-  const [scanHistory, setScanHistory] = useState([])
-  const [isLoadingHistory, setIsLoadingHistory] = useState(false)
-  const [historyError, setHistoryError] = useState(null)
-
   const isAuthenticated = Boolean(user)
   const canStartScan = isAuthenticated && !authLoading
   const isDashboardActive = location.pathname === "/"
-  const isResultsActive = location.pathname.startsWith("/scan/")
+  const isResultsActive =
+    location.pathname.startsWith("/scan/") || location.pathname === "/runs"
   const resultsDisabled = !isAuthenticated || authLoading
 
   useEffect(() => {
-    isMountedRef.current = true
-    return () => {
-      isMountedRef.current = false
-    }
-  }, [])
-
-  const fetchScanHistory = useCallback(async () => {
-    if (!isMountedRef.current) {
-      return
-    }
-
-    if (!isAuthenticated || authLoading) {
-      if (isMountedRef.current) {
-        setScanHistory([])
-        setHistoryError(null)
-        setIsLoadingHistory(false)
-      }
-      return
-    }
-
-    if (isMountedRef.current) {
-      setIsLoadingHistory(true)
-      setHistoryError(null)
-    }
-
-    try {
-      const response = await axios.get("/runs")
-      if (isMountedRef.current) {
-        setScanHistory(response.data || [])
-      }
-    } catch (error) {
-      if (!isMountedRef.current) {
-        return
-      }
-      if (error.response?.status === 401) {
-        setScanHistory([])
-      } else {
-        setHistoryError(error.response?.data?.detail || "Unable to load scan history")
-      }
-    } finally {
-      if (isMountedRef.current) {
-        setIsLoadingHistory(false)
-      }
-    }
-  }, [isAuthenticated, authLoading])
-
-  useEffect(() => {
-    fetchScanHistory()
-  }, [fetchScanHistory, currentScan?.runId])
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      setScanHistory([])
-      setHistoryError(null)
-    }
-  }, [isAuthenticated])
-
-  useEffect(() => {
-    setShowResultsDropdown(false)
-    setShowMobileResults(false)
+    setIsMenuOpen(false)
   }, [location.pathname])
 
   const handleNewScanClick = () => {
@@ -147,99 +55,13 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
     }
   }
 
-  const handleToggleDesktopResults = async () => {
-    if (resultsDisabled) return
-    if (!showResultsDropdown && !isLoadingHistory) {
-      await fetchScanHistory()
+  const handleResultsClick = (event) => {
+    if (resultsDisabled) {
+      event.preventDefault()
+      if (!authLoading) {
+        navigate("/login")
+      }
     }
-    setShowResultsDropdown((prev) => !prev)
-  }
-
-  const handleToggleMobileResults = async () => {
-    if (resultsDisabled) return
-    if (!showMobileResults && !isLoadingHistory) {
-      await fetchScanHistory()
-    }
-    setShowMobileResults((prev) => !prev)
-  }
-
-  const handleSelectScan = () => {
-    setShowResultsDropdown(false)
-    setShowMobileResults(false)
-    setIsMenuOpen(false)
-  }
-
-  const renderHistoryList = () => {
-    if (isLoadingHistory) {
-      return (
-        <div className="py-6 text-center text-sm text-muted-foreground">
-          Loading scan history...
-        </div>
-      )
-    }
-
-    if (historyError) {
-      return (
-        <div className="py-6 px-4 text-sm text-rose-400">
-          {historyError}
-        </div>
-      )
-    }
-
-    if (!scanHistory.length) {
-      return (
-        <div className="py-6 px-4 text-sm text-muted-foreground">
-          No scans yet. Start a scan to see your history here.
-        </div>
-      )
-    }
-
-    return (
-      <div className="py-2">
-        {scanHistory.map((scan) => {
-          const isActiveScan = location.pathname === `/scan/${scan.id}`
-          return (
-            <Link
-              key={scan.id}
-              to={`/scan/${scan.id}`}
-              className="block"
-              onClick={handleSelectScan}
-            >
-              <div
-                className={`px-4 py-3 transition-colors rounded-lg ${
-                  isActiveScan
-                    ? "bg-primary/10 border border-primary/30"
-                    : "hover:bg-primary/5"
-                }`}
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-foreground truncate">
-                      {scan.target_url}
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Started {formatDateTime(scan.created_at)}
-                    </p>
-                    <p className="mt-2 text-xs text-muted-foreground">
-                      Findings: <span className="font-medium text-foreground">{scan.finding_count ?? 0}</span>
-                      <span className="mx-1">•</span>
-                      Risk score: <span className="font-medium text-foreground">{scan.risk_score ?? 0}</span>
-                    </p>
-                  </div>
-                  <span
-                    className={`shrink-0 px-2 py-1 text-xs font-semibold rounded-full ${
-                      STATUS_STYLES[scan.status] || "bg-muted text-foreground/80"
-                    }`}
-                  >
-                    {formatStatusLabel(scan.status)}
-                  </span>
-                </div>
-              </div>
-            </Link>
-          )
-        })}
-      </div>
-    )
   }
 
   return (
@@ -297,52 +119,27 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
                 )}
               </Link>
 
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={handleToggleDesktopResults}
-                  className={`relative flex items-center space-x-1 text-sm font-medium transition-colors duration-200 ${
-                    resultsDisabled
-                      ? "text-foreground/30 cursor-not-allowed"
-                      : isResultsActive
-                      ? "text-primary"
-                      : "text-foreground/70 hover:text-foreground"
-                  }`}
-                  disabled={resultsDisabled}
-                >
-                  <span>Results</span>
-                  <ChevronDown
-                    className={`h-4 w-4 transition-transform ${
-                      showResultsDropdown ? "rotate-180" : "rotate-0"
-                    }`}
+              <Link
+                to="/runs"
+                onClick={handleResultsClick}
+                className={`relative text-sm font-medium transition-colors duration-200 ${
+                  resultsDisabled
+                    ? "text-foreground/30 cursor-not-allowed"
+                    : isResultsActive
+                    ? "text-primary"
+                    : "text-foreground/70 hover:text-foreground"
+                }`}
+              >
+                Results
+                {isResultsActive && !resultsDisabled && (
+                  <motion.div
+                    className="absolute -bottom-1 left-0 right-0 h-0.5 bg-primary"
+                    layoutId="activeTab"
+                    initial={false}
+                    transition={{ type: "spring", stiffness: 500, damping: 30 }}
                   />
-                  {isResultsActive && !resultsDisabled && (
-                    <motion.div
-                      className="absolute -bottom-1 left-0 right-0 h-0.5 bg-primary"
-                      layoutId="activeTab"
-                      initial={false}
-                      transition={{ type: "spring", stiffness: 500, damping: 30 }}
-                    />
-                  )}
-                </button>
-
-                <AnimatePresence>
-                  {showResultsDropdown && !resultsDisabled && (
-                    <motion.div
-                      key="results-dropdown"
-                      className="absolute right-0 mt-3 w-80 glass-card no-contain border border-border/50 rounded-xl shadow-2xl overflow-hidden z-40"
-                      initial={{ opacity: 0, y: -8 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -8 }}
-                      transition={{ duration: 0.2 }}
-                    >
-                      <div className="max-h-96 overflow-y-auto">
-                        {renderHistoryList()}
-                      </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
+                )}
+              </Link>
             </nav>
 
             {/* Auth Actions */}
@@ -450,43 +247,24 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
                     Dashboard
                   </Link>
 
-                  <div className="glass-card no-contain border border-border/50 rounded-lg">
-                    <button
-                      type="button"
-                      onClick={handleToggleMobileResults}
-                      className={`w-full flex items-center justify-between px-4 py-2 text-sm font-medium transition-colors ${
-                        resultsDisabled
-                          ? "text-foreground/30 cursor-not-allowed"
-                          : isResultsActive
-                          ? "text-primary"
-                          : "text-foreground/70 hover:text-foreground"
-                      }`}
-                      disabled={resultsDisabled}
-                    >
-                      <span>Results</span>
-                      <ChevronDown
-                        className={`h-4 w-4 transition-transform ${
-                          showMobileResults ? "rotate-180" : "rotate-0"
-                        }`}
-                      />
-                    </button>
-                    <AnimatePresence initial={false}>
-                      {showMobileResults && !resultsDisabled && (
-                        <motion.div
-                          key="mobile-results"
-                          initial={{ opacity: 0, height: 0 }}
-                          animate={{ opacity: 1, height: "auto" }}
-                          exit={{ opacity: 0, height: 0 }}
-                          transition={{ duration: 0.2 }}
-                          className="border-t border-border/40"
-                        >
-                          <div className="max-h-80 overflow-y-auto">
-                            {renderHistoryList()}
-                          </div>
-                        </motion.div>
-                      )}
-                    </AnimatePresence>
-                  </div>
+                  <Link
+                    to="/runs"
+                    onClick={(event) => {
+                      handleResultsClick(event)
+                      if (!resultsDisabled) {
+                        setIsMenuOpen(false)
+                      }
+                    }}
+                    className={`glass-card px-4 py-2 text-sm font-medium border border-border/50 rounded-lg transition-colors ${
+                      resultsDisabled
+                        ? "text-foreground/30 cursor-not-allowed"
+                        : isResultsActive
+                        ? "text-primary"
+                        : "text-foreground/70 hover:text-foreground"
+                    }`}
+                  >
+                    Results
+                  </Link>
 
                   {isAuthenticated ? (
                     <>

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -1,38 +1,117 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
+import axios from "axios"
 import { Link, useLocation, useNavigate } from "react-router-dom"
 import { motion, AnimatePresence } from "framer-motion"
-import { Shield, Play, AlertTriangle, LogOut, User } from "lucide-react"
+import { Shield, Play, AlertTriangle, LogOut, User, ChevronDown } from "lucide-react"
+
+const STATUS_STYLES = {
+  queued: "bg-amber-500/10 text-amber-400",
+  running: "bg-sky-500/10 text-sky-400",
+  completed: "bg-emerald-500/10 text-emerald-400",
+  failed: "bg-rose-500/10 text-rose-400"
+}
+
+const formatStatusLabel = (status) => {
+  if (!status) return ""
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}
+
+const formatDateTime = (value) => {
+  if (!value) return ""
+  try {
+    return new Date(value).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit"
+    })
+  } catch (error) {
+    return value
+  }
+}
 
 const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = false }) => {
   const location = useLocation()
   const navigate = useNavigate()
+  const isMountedRef = useRef(true)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
+  const [showResultsDropdown, setShowResultsDropdown] = useState(false)
+  const [showMobileResults, setShowMobileResults] = useState(false)
+  const [scanHistory, setScanHistory] = useState([])
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false)
+  const [historyError, setHistoryError] = useState(null)
 
   const isAuthenticated = Boolean(user)
   const canStartScan = isAuthenticated && !authLoading
+  const isDashboardActive = location.pathname === "/"
+  const isResultsActive = location.pathname.startsWith("/scan/")
+  const resultsDisabled = !isAuthenticated || authLoading
 
-  // Check if we're currently on a scan results page
-  const isOnScanResults = location.pathname.startsWith("/scan/")
-
-  const navItems = [
-    { name: "Dashboard", path: "/", disabled: !isAuthenticated || authLoading },
-    {
-      name: "Results",
-      path: currentScan ? `/scan/${currentScan.runId}` : (isOnScanResults ? location.pathname : "/"),
-      disabled: !isAuthenticated || authLoading || (!currentScan && !isOnScanResults)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
     }
-  ]
+  }, [])
 
-  const isActive = (path) => {
-    if (path === "/") {
-      return location.pathname === "/"
+  const fetchScanHistory = useCallback(async () => {
+    if (!isMountedRef.current) {
+      return
     }
-    // For Results tab, show as active when on any scan results page
-    return location.pathname.startsWith("/scan/")
-  }
+
+    if (!isAuthenticated || authLoading) {
+      if (isMountedRef.current) {
+        setScanHistory([])
+        setHistoryError(null)
+        setIsLoadingHistory(false)
+      }
+      return
+    }
+
+    if (isMountedRef.current) {
+      setIsLoadingHistory(true)
+      setHistoryError(null)
+    }
+
+    try {
+      const response = await axios.get("/runs")
+      if (isMountedRef.current) {
+        setScanHistory(response.data || [])
+      }
+    } catch (error) {
+      if (!isMountedRef.current) {
+        return
+      }
+      if (error.response?.status === 401) {
+        setScanHistory([])
+      } else {
+        setHistoryError(error.response?.data?.detail || "Unable to load scan history")
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setIsLoadingHistory(false)
+      }
+    }
+  }, [isAuthenticated, authLoading])
+
+  useEffect(() => {
+    fetchScanHistory()
+  }, [fetchScanHistory, currentScan?.runId])
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setScanHistory([])
+      setHistoryError(null)
+    }
+  }, [isAuthenticated])
+
+  useEffect(() => {
+    setShowResultsDropdown(false)
+    setShowMobileResults(false)
+  }, [location.pathname])
 
   const handleNewScanClick = () => {
     if (!canStartScan) {
@@ -42,11 +121,9 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
       return
     }
 
-    // If there's an active scan, show confirmation dialog
     if (currentScan && (currentScan.status === "running" || currentScan.status === "completed")) {
       setShowConfirmDialog(true)
     } else {
-      // No active scan, go directly to dashboard
       navigate("/")
     }
   }
@@ -54,7 +131,6 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
   const handleConfirmNewScan = () => {
     setShowConfirmDialog(false)
     navigate("/")
-    // Call the onNewScan callback to reset the current scan state
     if (onNewScan) {
       onNewScan()
     }
@@ -69,6 +145,101 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
       await onLogout()
       setIsMenuOpen(false)
     }
+  }
+
+  const handleToggleDesktopResults = async () => {
+    if (resultsDisabled) return
+    if (!showResultsDropdown && !isLoadingHistory) {
+      await fetchScanHistory()
+    }
+    setShowResultsDropdown((prev) => !prev)
+  }
+
+  const handleToggleMobileResults = async () => {
+    if (resultsDisabled) return
+    if (!showMobileResults && !isLoadingHistory) {
+      await fetchScanHistory()
+    }
+    setShowMobileResults((prev) => !prev)
+  }
+
+  const handleSelectScan = () => {
+    setShowResultsDropdown(false)
+    setShowMobileResults(false)
+    setIsMenuOpen(false)
+  }
+
+  const renderHistoryList = () => {
+    if (isLoadingHistory) {
+      return (
+        <div className="py-6 text-center text-sm text-muted-foreground">
+          Loading scan history...
+        </div>
+      )
+    }
+
+    if (historyError) {
+      return (
+        <div className="py-6 px-4 text-sm text-rose-400">
+          {historyError}
+        </div>
+      )
+    }
+
+    if (!scanHistory.length) {
+      return (
+        <div className="py-6 px-4 text-sm text-muted-foreground">
+          No scans yet. Start a scan to see your history here.
+        </div>
+      )
+    }
+
+    return (
+      <div className="py-2">
+        {scanHistory.map((scan) => {
+          const isActiveScan = location.pathname === `/scan/${scan.id}`
+          return (
+            <Link
+              key={scan.id}
+              to={`/scan/${scan.id}`}
+              className="block"
+              onClick={handleSelectScan}
+            >
+              <div
+                className={`px-4 py-3 transition-colors rounded-lg ${
+                  isActiveScan
+                    ? "bg-primary/10 border border-primary/30"
+                    : "hover:bg-primary/5"
+                }`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-foreground truncate">
+                      {scan.target_url}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Started {formatDateTime(scan.created_at)}
+                    </p>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      Findings: <span className="font-medium text-foreground">{scan.finding_count ?? 0}</span>
+                      <span className="mx-1">•</span>
+                      Risk score: <span className="font-medium text-foreground">{scan.risk_score ?? 0}</span>
+                    </p>
+                  </div>
+                  <span
+                    className={`shrink-0 px-2 py-1 text-xs font-semibold rounded-full ${
+                      STATUS_STYLES[scan.status] || "bg-muted text-foreground/80"
+                    }`}
+                  >
+                    {formatStatusLabel(scan.status)}
+                  </span>
+                </div>
+              </div>
+            </Link>
+          )
+        })}
+      </div>
+    )
   }
 
   return (
@@ -105,20 +276,47 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
 
             {/* Navigation Links */}
             <nav className="hidden md:flex items-center space-x-8">
-              {navItems.map((item) => (
-                <Link
-                  key={item.name}
-                  to={item.path}
-                  className={`relative text-sm font-medium transition-colors duration-200 ${
-                    item.disabled
+              <Link
+                to="/"
+                className={`relative text-sm font-medium transition-colors duration-200 ${
+                  !isAuthenticated || authLoading
+                    ? "text-foreground/30 cursor-not-allowed"
+                    : isDashboardActive
+                    ? "text-primary"
+                    : "text-foreground/70 hover:text-foreground"
+                }`}
+              >
+                Dashboard
+                {isDashboardActive && isAuthenticated && !authLoading && (
+                  <motion.div
+                    className="absolute -bottom-1 left-0 right-0 h-0.5 bg-primary"
+                    layoutId="activeTab"
+                    initial={false}
+                    transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                  />
+                )}
+              </Link>
+
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={handleToggleDesktopResults}
+                  className={`relative flex items-center space-x-1 text-sm font-medium transition-colors duration-200 ${
+                    resultsDisabled
                       ? "text-foreground/30 cursor-not-allowed"
-                      : isActive(item.path)
+                      : isResultsActive
                       ? "text-primary"
                       : "text-foreground/70 hover:text-foreground"
                   }`}
+                  disabled={resultsDisabled}
                 >
-                  {item.name}
-                  {isActive(item.path) && !item.disabled && (
+                  <span>Results</span>
+                  <ChevronDown
+                    className={`h-4 w-4 transition-transform ${
+                      showResultsDropdown ? "rotate-180" : "rotate-0"
+                    }`}
+                  />
+                  {isResultsActive && !resultsDisabled && (
                     <motion.div
                       className="absolute -bottom-1 left-0 right-0 h-0.5 bg-primary"
                       layoutId="activeTab"
@@ -126,8 +324,25 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
                       transition={{ type: "spring", stiffness: 500, damping: 30 }}
                     />
                   )}
-                </Link>
-              ))}
+                </button>
+
+                <AnimatePresence>
+                  {showResultsDropdown && !resultsDisabled && (
+                    <motion.div
+                      key="results-dropdown"
+                      className="absolute right-0 mt-3 w-80 glass-card border border-border/50 rounded-xl shadow-2xl overflow-hidden"
+                      initial={{ opacity: 0, y: -8 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -8 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      <div className="max-h-96 overflow-y-auto">
+                        {renderHistoryList()}
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
             </nav>
 
             {/* Auth Actions */}
@@ -207,72 +422,110 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
           </div>
 
           {/* Mobile Menu */}
-          {isMenuOpen && (
-            <motion.div
-              className="md:hidden py-4 border-t border-border/50"
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.2 }}
-            >
-              <div className="flex flex-col space-y-4">
-                {navItems.map((item) => (
+          <AnimatePresence initial={false}>
+            {isMenuOpen && (
+              <motion.div
+                className="md:hidden py-4 border-t border-border/50"
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                <div className="flex flex-col space-y-4">
                   <Link
-                    key={item.name}
-                    to={item.path}
+                    to="/"
                     className={`text-sm font-medium transition-colors duration-200 ${
-                      item.disabled
+                      !isAuthenticated || authLoading
                         ? "text-foreground/30 cursor-not-allowed"
-                        : isActive(item.path)
+                        : isDashboardActive
                         ? "text-primary"
                         : "text-foreground/70 hover:text-foreground"
                     }`}
                     onClick={() => {
-                      if (!item.disabled) {
+                      if (isAuthenticated && !authLoading) {
                         setIsMenuOpen(false)
                       }
                     }}
                   >
-                    {item.name}
+                    Dashboard
                   </Link>
-                ))}
-                {isAuthenticated ? (
-                  <>
+
+                  <div className="glass-card border border-border/50 rounded-lg">
                     <button
-                      onClick={handleNewScanClick}
-                      disabled={!canStartScan}
-                      className="glass-card px-4 py-2 text-left text-sm font-medium text-foreground border border-border/50 rounded-lg hover:bg-primary/10 disabled:opacity-50"
+                      type="button"
+                      onClick={handleToggleMobileResults}
+                      className={`w-full flex items-center justify-between px-4 py-2 text-sm font-medium transition-colors ${
+                        resultsDisabled
+                          ? "text-foreground/30 cursor-not-allowed"
+                          : isResultsActive
+                          ? "text-primary"
+                          : "text-foreground/70 hover:text-foreground"
+                      }`}
+                      disabled={resultsDisabled}
                     >
-                      Start new scan
+                      <span>Results</span>
+                      <ChevronDown
+                        className={`h-4 w-4 transition-transform ${
+                          showMobileResults ? "rotate-180" : "rotate-0"
+                        }`}
+                      />
                     </button>
-                    <button
-                      onClick={handleLogoutClick}
-                      className="glass-card px-4 py-2 text-left text-sm font-medium text-foreground border border-border/50 rounded-lg hover:bg-muted/20"
-                    >
-                      Log out
-                    </button>
-                  </>
-                ) : (
-                  <div className="flex flex-col space-y-3">
-                    <Link
-                      to="/login"
-                      className="glass-card px-4 py-2 text-sm font-medium text-foreground border border-border/50 rounded-lg hover:bg-muted/20"
-                      onClick={() => setIsMenuOpen(false)}
-                    >
-                      Log in
-                    </Link>
-                    <Link
-                      to="/signup"
-                      className="bg-primary text-primary-foreground px-4 py-2 text-sm font-medium rounded-lg hover:bg-primary/90"
-                      onClick={() => setIsMenuOpen(false)}
-                    >
-                      Sign up
-                    </Link>
+                    <AnimatePresence initial={false}>
+                      {showMobileResults && !resultsDisabled && (
+                        <motion.div
+                          key="mobile-results"
+                          initial={{ opacity: 0, height: 0 }}
+                          animate={{ opacity: 1, height: "auto" }}
+                          exit={{ opacity: 0, height: 0 }}
+                          transition={{ duration: 0.2 }}
+                          className="border-t border-border/40"
+                        >
+                          <div className="max-h-80 overflow-y-auto">
+                            {renderHistoryList()}
+                          </div>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
                   </div>
-                )}
-              </div>
-            </motion.div>
-          )}
+
+                  {isAuthenticated ? (
+                    <>
+                      <button
+                        onClick={handleNewScanClick}
+                        disabled={!canStartScan}
+                        className="glass-card px-4 py-2 text-left text-sm font-medium text-foreground border border-border/50 rounded-lg hover:bg-primary/10 disabled:opacity-50"
+                      >
+                        Start new scan
+                      </button>
+                      <button
+                        onClick={handleLogoutClick}
+                        className="glass-card px-4 py-2 text-left text-sm font-medium text-foreground border border-border/50 rounded-lg hover:bg-muted/20"
+                      >
+                        Log out
+                      </button>
+                    </>
+                  ) : (
+                    <div className="flex flex-col space-y-3">
+                      <Link
+                        to="/login"
+                        className="glass-card px-4 py-2 text-sm font-medium text-foreground border border-border/50 rounded-lg hover:bg-muted/20"
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        Log in
+                      </Link>
+                      <Link
+                        to="/signup"
+                        className="bg-primary text-primary-foreground px-4 py-2 text-sm font-medium rounded-lg hover:bg-primary/90"
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        Sign up
+                      </Link>
+                    </div>
+                  )}
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
       </motion.header>
 
@@ -344,4 +597,3 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
 }
 
 export default NavigationBar
-

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -245,7 +245,7 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
   return (
     <>
       <motion.header
-        className="glass-card border-b border-border/50 relative z-10"
+        className="glass-card no-contain border-b border-border/50 relative z-30"
         initial={{ y: -100, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.6, ease: "easeOut" }}
@@ -330,7 +330,7 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
                   {showResultsDropdown && !resultsDisabled && (
                     <motion.div
                       key="results-dropdown"
-                      className="absolute right-0 mt-3 w-80 glass-card border border-border/50 rounded-xl shadow-2xl overflow-hidden"
+                      className="absolute right-0 mt-3 w-80 glass-card no-contain border border-border/50 rounded-xl shadow-2xl overflow-hidden z-40"
                       initial={{ opacity: 0, y: -8 }}
                       animate={{ opacity: 1, y: 0 }}
                       exit={{ opacity: 0, y: -8 }}
@@ -450,7 +450,7 @@ const NavigationBar = ({ currentScan, onNewScan, user, onLogout, authLoading = f
                     Dashboard
                   </Link>
 
-                  <div className="glass-card border border-border/50 rounded-lg">
+                  <div className="glass-card no-contain border border-border/50 rounded-lg">
                     <button
                       type="button"
                       onClick={handleToggleMobileResults}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -72,6 +72,10 @@ code {
   contain: layout style paint;
 }
 
+.no-contain {
+  contain: none;
+}
+
 .gradient-text {
   background: linear-gradient(135deg, hsl(var(--primary)), hsl(0 0% 100%));
   -webkit-background-clip: text;

--- a/frontend/src/pages/ScanHistoryPage.js
+++ b/frontend/src/pages/ScanHistoryPage.js
@@ -1,0 +1,227 @@
+"use client"
+
+import { useEffect, useState, useMemo } from "react"
+import { useNavigate, Link } from "react-router-dom"
+import axios from "axios"
+import { motion } from "framer-motion"
+import { History, RefreshCw, ArrowRight, AlertTriangle, Clock } from "lucide-react"
+
+const STATUS_STYLES = {
+  queued: "bg-amber-500/10 text-amber-400 border border-amber-500/20",
+  running: "bg-sky-500/10 text-sky-400 border border-sky-500/20",
+  completed: "bg-emerald-500/10 text-emerald-400 border border-emerald-500/20",
+  failed: "bg-rose-500/10 text-rose-400 border border-rose-500/20",
+}
+
+const formatDateTime = (value) => {
+  if (!value) return ""
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(new Date(value))
+  } catch (error) {
+    return value
+  }
+}
+
+const ScanHistoryPage = () => {
+  const navigate = useNavigate()
+  const [runs, setRuns] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  const hasRuns = runs.length > 0
+
+  const fetchRuns = async (isRefresh = false) => {
+    if (isRefresh) {
+      setIsRefreshing(true)
+    } else {
+      setLoading(true)
+    }
+    setError(null)
+
+    try {
+      const response = await axios.get("/runs")
+      setRuns(Array.isArray(response.data) ? response.data : [])
+    } catch (err) {
+      if (err.response?.status === 401) {
+        navigate("/login")
+        return
+      }
+      setError(err.response?.data?.detail || "Unable to load scan history")
+    } finally {
+      setLoading(false)
+      setIsRefreshing(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchRuns()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const summaryStats = useMemo(() => {
+    if (!runs.length) {
+      return { totalFindings: 0, avgRisk: 0 }
+    }
+
+    const totals = runs.reduce(
+      (acc, run) => {
+        acc.totalFindings += run.finding_count || 0
+        acc.totalRisk += run.risk_score || 0
+        return acc
+      },
+      { totalFindings: 0, totalRisk: 0 }
+    )
+
+    return {
+      totalFindings: totals.totalFindings,
+      avgRisk: Math.round((totals.totalRisk / runs.length) * 10) / 10,
+    }
+  }, [runs])
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+        <div>
+          <h2 className="text-3xl font-semibold text-foreground flex items-center gap-3">
+            <span className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-primary/10 text-primary">
+              <History className="w-6 h-6" />
+            </span>
+            Scan History
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground max-w-2xl">
+            Review every scan executed by your account, including when it was started,
+            how many findings were detected, and the overall risk scores.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => fetchRuns(true)}
+          disabled={loading || isRefreshing}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-border/50 text-sm font-medium text-foreground hover:bg-muted/30 transition disabled:opacity-50"
+        >
+          <RefreshCw className={`w-4 h-4 ${isRefreshing ? "animate-spin" : ""}`} />
+          Refresh
+        </button>
+      </div>
+
+      <motion.div
+        className="grid grid-cols-1 md:grid-cols-3 gap-4"
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.1 }}
+      >
+        <div className="glass-card border border-border/40 rounded-2xl p-6">
+          <p className="text-sm text-muted-foreground">Total Scans</p>
+          <p className="mt-2 text-3xl font-semibold text-foreground">{runs.length}</p>
+        </div>
+        <div className="glass-card border border-border/40 rounded-2xl p-6">
+          <p className="text-sm text-muted-foreground">Total Findings Logged</p>
+          <p className="mt-2 text-3xl font-semibold text-foreground">{summaryStats.totalFindings}</p>
+        </div>
+        <div className="glass-card border border-border/40 rounded-2xl p-6">
+          <p className="text-sm text-muted-foreground">Average Risk Score</p>
+          <p className="mt-2 text-3xl font-semibold text-foreground">{summaryStats.avgRisk}</p>
+        </div>
+      </motion.div>
+
+      <motion.div
+        className="glass-card no-contain border border-border/50 rounded-2xl overflow-hidden"
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.2 }}
+      >
+        {loading ? (
+          <div className="py-16 text-center text-muted-foreground text-sm">Loading scan history…</div>
+        ) : error ? (
+          <div className="py-16 px-6 text-center">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-rose-500/10 text-rose-400 text-sm font-medium">
+              <AlertTriangle className="w-4 h-4" />
+              Error loading history
+            </div>
+            <p className="mt-4 text-sm text-muted-foreground">{error}</p>
+            <button
+              type="button"
+              onClick={() => fetchRuns()}
+              className="mt-6 inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-border/50 text-sm font-medium text-foreground hover:bg-muted/30 transition"
+            >
+              Try again
+            </button>
+          </div>
+        ) : !hasRuns ? (
+          <div className="py-16 px-6 text-center space-y-4">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-muted/10 text-muted-foreground">
+              <Clock className="w-7 h-7" />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-foreground">No scans yet</h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Start a new scan from the dashboard to begin building your security history.
+              </p>
+            </div>
+            <Link
+              to="/"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition"
+            >
+              Launch your first scan
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+          </div>
+        ) : (
+          <div className="divide-y divide-border/50">
+            <div className="grid grid-cols-12 gap-4 px-6 py-4 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <span className="col-span-5">Target</span>
+              <span className="col-span-2">Status</span>
+              <span className="col-span-2">Findings</span>
+              <span className="col-span-2">Risk Score</span>
+              <span className="col-span-1 text-right">Started</span>
+            </div>
+            <div className="divide-y divide-border/40">
+              {runs.map((run) => (
+                <button
+                  key={run.id}
+                  type="button"
+                  onClick={() => navigate(`/scan/${run.id}`)}
+                  className="w-full text-left px-6 py-5 transition hover:bg-primary/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                >
+                  <div className="grid grid-cols-12 gap-4 items-center">
+                    <div className="col-span-5 min-w-0">
+                      <p className="text-sm font-medium text-foreground truncate">{run.target_url}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">Run ID: {run.id}</p>
+                    </div>
+                    <div className="col-span-2">
+                      <span
+                        className={`inline-flex items-center px-2.5 py-1 text-xs font-semibold rounded-full ${
+                          STATUS_STYLES[run.status] || "bg-muted text-foreground/80"
+                        }`}
+                      >
+                        {run.status ? run.status.charAt(0).toUpperCase() + run.status.slice(1) : "Unknown"}
+                      </span>
+                    </div>
+                    <div className="col-span-2 text-sm text-foreground">
+                      {run.finding_count ?? 0}
+                    </div>
+                    <div className="col-span-2 text-sm text-foreground">
+                      {run.risk_score ?? 0}
+                    </div>
+                    <div className="col-span-1 text-right text-xs text-muted-foreground">
+                      {formatDateTime(run.created_at)}
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </motion.div>
+    </div>
+  )
+}
+
+export default ScanHistoryPage


### PR DESCRIPTION
## Summary
- attach the authenticated user id to new scan runs and add a helper to query scans by owner
- expose a per-user `/runs` endpoint while securing existing scan APIs against cross-account access
- refresh the navigation bar to fetch account scan history and present it through desktop and mobile dropdowns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8a7c57d0c83338d8816c3c14bbd14