### PR TITLE
Send scan notifications to user and default email

### DIFF
--- a/backend/agent_mail.py
+++ b/backend/agent_mail.py
@@ -37,8 +37,8 @@ def _normalize_email_list(value: Optional[str]) -> List[str]:
     return candidates
 
 
-def _coalesce_notify_email(email: Optional[str]) -> Optional[str]:
-    """Return a comma-separated list of recipients including the default notification email."""
+def _coalesce_notify_email(email: Optional[str]) -> List[str]:
+    """Return a list of recipients including the default notification email."""
 
     recipients = _normalize_email_list(email)
 
@@ -49,10 +49,7 @@ def _coalesce_notify_email(email: Optional[str]) -> Optional[str]:
         if default_lower not in seen:
             recipients.append(default_email)
 
-    if not recipients:
-        return None
-
-    return ", ".join(recipients)
+    return recipients
 
 
 async def prepare_scan_digest(run_id: str) -> Dict[str, Any]:
@@ -168,8 +165,8 @@ async def dispatch_post_scan_email(run_id: str, *, error_message: Optional[str] 
         digest["error"] = error_message
         logger.info("⚠️ Email will report scan failure for run %s", run_id)
 
-    recipient = digest.get("resolved_notify_email") or _coalesce_notify_email(digest.get("notify_email"))
-    if not recipient:
+    recipients = digest.get("resolved_notify_email") or _coalesce_notify_email(digest.get("notify_email"))
+    if not recipients:
         logger.warning("❌ No recipient email resolved for run %s; skipping Agent Mail dispatch", run_id)
         return
 
@@ -179,7 +176,7 @@ async def dispatch_post_scan_email(run_id: str, *, error_message: Optional[str] 
 
     subject = f"Swarm scan {status_value} for {digest.get('target_url', '')}".strip()
     
-    logger.info("📧 Preparing to send email to %s with subject: '%s'", recipient, subject)
+    logger.info("📧 Preparing to send email to %s with subject: '%s'", ", ".join(recipients), subject)
 
     # Generate email body from the scan digest
     logger.debug("🎨 Generating email HTML body for run %s", run_id)
@@ -198,19 +195,19 @@ async def dispatch_post_scan_email(run_id: str, *, error_message: Optional[str] 
         logger.info("📤 Sending email via Agent Mail API...")
         await client.inboxes.messages.send(
             inbox_id=AGENTMAIL_INBOX_ID,
-            to=recipient,
+            to=recipients,
             subject=subject,
             html=email_body,
         )
         
         logger.info("✅ Agent Mail email successfully sent for run %s to %s (subject: '%s')", 
-                   run_id, recipient, subject)
+                   run_id, ", ".join(recipients), subject)
         
     except Exception as exc:
-        logger.error("❌ Agent Mail dispatch failed for run %s to %s: %s", run_id, recipient, exc)
+        logger.error("❌ Agent Mail dispatch failed for run %s to %s: %s", run_id, ", ".join(recipients), exc)
         # Log additional context for debugging
         logger.debug("Failed email details - inbox_id: %s, recipient: %s, subject length: %d chars, body size: %d KB", 
-                    AGENTMAIL_INBOX_ID, recipient, len(subject), body_size_kb)
+                    AGENTMAIL_INBOX_ID, ", ".join(recipients), len(subject), body_size_kb)
         
         # Log specific API error details if available
         if hasattr(exc, 'status_code'):

--- a/backend/agent_mail.py
+++ b/backend/agent_mail.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from database import get_findings_by_run, get_scan_run
 from models import ScanStatus
@@ -17,10 +17,42 @@ AGENTMAIL_API_KEY = os.getenv("AGENTMAIL_API_KEY")
 SEVERITY_ORDER = ["critical", "high", "medium", "low", "info"]
 
 
+def _normalize_email_list(value: Optional[str]) -> List[str]:
+    """Split a comma/semicolon separated string into unique, lowercase-insensitive addresses."""
+
+    if not value:
+        return []
+
+    candidates: List[str] = []
+    seen = set()
+    for part in value.replace(";", ",").split(","):
+        addr = part.strip()
+        if not addr:
+            continue
+        lower_addr = addr.lower()
+        if lower_addr in seen:
+            continue
+        seen.add(lower_addr)
+        candidates.append(addr)
+    return candidates
+
+
 def _coalesce_notify_email(email: Optional[str]) -> Optional[str]:
-    if email and email.strip():
-        return email.strip()
-    return DEFAULT_NOTIFY_EMAIL
+    """Return a comma-separated list of recipients including the default notification email."""
+
+    recipients = _normalize_email_list(email)
+
+    default_email = (DEFAULT_NOTIFY_EMAIL or "").strip()
+    if default_email:
+        default_lower = default_email.lower()
+        seen = {addr.lower() for addr in recipients}
+        if default_lower not in seen:
+            recipients.append(default_email)
+
+    if not recipients:
+        return None
+
+    return ", ".join(recipients)
 
 
 async def prepare_scan_digest(run_id: str) -> Dict[str, Any]:
@@ -98,7 +130,8 @@ async def prepare_scan_digest(run_id: str) -> Dict[str, Any]:
         "ai_generated_findings": ai_generated_count,
         "finding_summary": severity_totals,
         "highest_severity": highest_severity,
-        "notify_email": _coalesce_notify_email(getattr(run, "notify_email", None)),
+        "notify_email": getattr(run, "notify_email", None),
+        "resolved_notify_email": _coalesce_notify_email(getattr(run, "notify_email", None)),
         "consent_ip": getattr(run, "consent_ip", None),
         "max_pages": getattr(run, "max_pages", None),
         "findings": findings_payload,
@@ -135,7 +168,7 @@ async def dispatch_post_scan_email(run_id: str, *, error_message: Optional[str] 
         digest["error"] = error_message
         logger.info("⚠️ Email will report scan failure for run %s", run_id)
 
-    recipient = _coalesce_notify_email(digest.get("notify_email"))
+    recipient = digest.get("resolved_notify_email") or _coalesce_notify_email(digest.get("notify_email"))
     if not recipient:
         logger.warning("❌ No recipient email resolved for run %s; skipping Agent Mail dispatch", run_id)
         return

--- a/backend/main.py
+++ b/backend/main.py
@@ -292,7 +292,9 @@ async def create_scan(
     # Create scan run
     run_id = str(uuid.uuid4())[:8]
 
-    notify_email = scan_request.notify_email or os.getenv("DEFAULT_NOTIFY_EMAIL", "vnannapu@umich.edu")
+    default_notify_email = (os.getenv("DEFAULT_NOTIFY_EMAIL", "vnannapu@umich.edu") or "").strip()
+
+    notify_email = (scan_request.notify_email or "").strip() or None
 
     scan_data = {
         "id": run_id,
@@ -300,7 +302,7 @@ async def create_scan(
         "name": scan_request.name,
         "status": ScanStatus.QUEUED,
         "max_pages": scan_request.max_pages,
-        "notify_email": notify_email,
+        "notify_email": notify_email or default_notify_email or None,
         "consent_ip": request.client.host,
         "user_id": user["id"],
     }


### PR DESCRIPTION
## Summary
- ensure scan creation stores trimmed user-provided notification email while still falling back to the default
- combine user and default addresses when resolving notification recipients and expose the resolved list in the scan digest

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8c2cbfd4c833398742a989d159935